### PR TITLE
fix : 파티 요청사항 1차 완료

### DIFF
--- a/backend/src/main/java/com/back/domain/party/party/controller/ApiV1PartyController.java
+++ b/backend/src/main/java/com/back/domain/party/party/controller/ApiV1PartyController.java
@@ -1,5 +1,6 @@
 package com.back.domain.party.party.controller;
 
+import com.back.domain.mission.enums.MissionCategory;
 import com.back.domain.party.party.dto.*;
 import com.back.domain.party.party.entity.Party;
 import com.back.domain.party.party.entity.PartyMember;
@@ -11,11 +12,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -112,16 +118,17 @@ public class ApiV1PartyController {
     }
 
     @GetMapping
-    @Operation(summary = "파티 목록 조회", description = "공개 파티 목록을 조회하는 API")
-    public ResponseEntity<ApiResponse<List<PartyDto>>> getPartyList() {
-        List<Party> parties = partyService.getPartyList();
-        List<PartyDto> partyDtos = parties.stream()
-                .map(PartyDto::new)
-                .collect(Collectors.toList());
+    @Operation(summary = "파티 목록 조회", description = "공개 파티 목록을 조회하고, 정렬(최신순/조회순) 및 필터링(카테고리/시작일)을 지원합니다.")
+    public ResponseEntity<ApiResponse<Page<PartyDto>>> getPublicParties(
+            @ParameterObject Pageable pageable,
+            @RequestParam(required = false) MissionCategory category,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate
+    ) {
+        Page<PartyDto> partyPage = partyService.getPublicPartyList(pageable, category, startDate);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(ApiResponse.success("200", "파티 목록 조회 성공", partyDtos));
+                .body(ApiResponse.success("200", "파티 목록 조회 성공", partyPage));
     }
 
     @GetMapping("/{partyId}")

--- a/backend/src/main/java/com/back/domain/party/party/dto/PartyDto.java
+++ b/backend/src/main/java/com/back/domain/party/party/dto/PartyDto.java
@@ -1,10 +1,14 @@
 package com.back.domain.party.party.dto;
 
+import com.back.domain.mission.entity.Mission;
+import com.back.domain.mission.enums.MissionCategory;
 import com.back.domain.party.party.entity.Party;
+import com.back.domain.party.party.entity.PartyMemberStatus;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -19,21 +23,64 @@ public class PartyDto {
     private Integer maxMembers;
     private Boolean isPublic;
     private List<PartyMemberDto> members;
+    private MissionCategory category;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalDate createDate;
+    private Integer views;
 
-    // 미션 도메인 완성 시 사용
-    // private Integer missionId;
+
+    public PartyDto(Party party, Mission mission) {
+        this.id = party.getId();
+        this.name = party.getName();
+        this.leaderId = party.getLeader().getId();
+
+        this.currentMembers = (int) party.getPartyMembers().stream()
+                .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
+                .count();
+
+        this.maxMembers = party.getMaxMembers();
+        this.isPublic = party.isPublic();
+
+        this.createDate = party.getCreateDate().toLocalDate();
+
+        this.views = party.getViews();
+
+        if (mission != null) {
+            this.category = mission.getCategory();
+            this.startDate = mission.getStartDate();
+            this.endDate = mission.getEndDate();
+        }
+
+        this.members = party.getPartyMembers().stream()
+                .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
+                .map(partyMember -> new PartyMemberDto(partyMember.getMember()))
+                .collect(Collectors.toList());
+    }
 
     public PartyDto(Party party) {
         this.id = party.getId();
         this.name = party.getName();
         this.leaderId = party.getLeader().getId();
-        this.currentMembers = party.getPartyMembers().size();
+
+        this.currentMembers = (int) party.getPartyMembers().stream()
+                .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
+                .count();
+
         this.maxMembers = party.getMaxMembers();
         this.isPublic = party.isPublic();
+
+        this.createDate = party.getCreateDate().toLocalDate();
+        this.views = party.getViews();
+
+        this.category = null;
+        this.startDate = null;
+        this.endDate = null;
+
         this.members = party.getPartyMembers().stream()
+                .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
                 .map(partyMember -> new PartyMemberDto(partyMember.getMember()))
                 .collect(Collectors.toList());
-        // missionId는 미션 도메인 완성 후 추가
-        // this.missionId = party.getMission().getId();
     }
+
 }

--- a/backend/src/main/java/com/back/domain/party/party/entity/Party.java
+++ b/backend/src/main/java/com/back/domain/party/party/entity/Party.java
@@ -27,9 +27,12 @@ public class Party extends BaseEntity {
     @JoinColumn(name = "leader_id")
     private Member leader;
 
-// @ManyToOne(fetch = FetchType.LAZY)
-// @JoinColumn(name = "mission_id")
-// private Mission mission;
+    @Column(nullable = false)
+    private Integer views = 0;
+
+    public void incrementViews() {
+        this.views++;
+    }
 
     @OneToMany(mappedBy = "party", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PartyMember> partyMembers = new ArrayList<>();

--- a/backend/src/main/java/com/back/domain/party/party/repository/PartyRepository.java
+++ b/backend/src/main/java/com/back/domain/party/party/repository/PartyRepository.java
@@ -1,8 +1,11 @@
 package com.back.domain.party.party.repository;
 
 import com.back.domain.party.party.entity.Party;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -25,6 +28,11 @@ public interface PartyRepository extends JpaRepository<Party, Integer> {
     @EntityGraph(attributePaths = {"leader", "partyMembers.member"})
     Optional<Party> findById(Integer partyId);
 
-    // 특정 미션을 진행하는 파티를 찾는 메서드 (미션 도메인 완성 시 사용)
-    // Optional<Party> findByMission_Id(Integer missionId);
+    @Query(value = "SELECT DISTINCT p FROM Party p " +
+            "LEFT JOIN FETCH p.leader l " +
+            "LEFT JOIN p.partyMembers pm " +
+            "LEFT JOIN Mission m ON m.party = p " +
+            "WHERE p.isPublic = true",
+            countQuery = "SELECT COUNT(p) FROM Party p WHERE p.isPublic = true")
+    Page<Party> findPublicPartiesWithMissionAndMembers(Pageable pageable);
 }

--- a/backend/src/main/java/com/back/domain/party/party/service/PartyService.java
+++ b/backend/src/main/java/com/back/domain/party/party/service/PartyService.java
@@ -2,6 +2,10 @@ package com.back.domain.party.party.service;
 
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
+import com.back.domain.mission.entity.Mission;
+import com.back.domain.mission.enums.MissionCategory;
+import com.back.domain.mission.repository.MissionRepository;
+import com.back.domain.party.party.dto.PartyDto;
 import com.back.domain.party.party.dto.PartyRequestDto;
 import com.back.domain.party.party.dto.PartyUpdateRequestDto;
 import com.back.domain.party.party.entity.Party;
@@ -14,13 +18,19 @@ import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -30,6 +40,42 @@ public class PartyService {
     private final PartyRepository partyRepository;
     private final MemberRepository memberRepository;
     private final PartyMemberRepository partyMemberRepository;
+    private final MissionRepository missionRepository;
+
+    public Page<PartyDto> getPublicPartyList(
+            Pageable pageable,
+            MissionCategory categoryFilter,
+            LocalDate startDateFilter
+    ) {
+        // 1. Repository를 사용하여 페이징 및 정렬된 Party 리스트 조회 (Mission, Leader, Members 포함)
+        Page<Party> partyPage = partyRepository.findPublicPartiesWithMissionAndMembers(pageable);
+        List<Party> parties = partyPage.getContent();
+
+        // 2. 파티 목록을 PartyDto로 변환하면서 Mission 정보를 매핑하고 필터링
+        List<PartyDto> dtoList = parties.stream()
+                .map(party -> {
+                    // MissionRepository를 사용하여 파티에 연결된 Mission을 조회 (파티당 하나의 미션만 있다고 가정)
+                    Optional<Mission> missionOptional = missionRepository.findByPartyId(party.getId()).stream().findFirst();
+
+                    // Mission 정보를 포함하는 생성자로 DTO 생성
+                    PartyDto dto = new PartyDto(party, missionOptional.orElse(null));
+
+                    // 3. Service에서 필터링 조건 확인 (DB 쿼리로 처리할 수 없는 동적 필터링을 여기서 처리)
+                    if (categoryFilter != null && (dto.getCategory() == null || !dto.getCategory().equals(categoryFilter))) {
+                        return null; // 카테고리 필터 불일치
+                    }
+                    if (startDateFilter != null && (dto.getStartDate() == null || !dto.getStartDate().isEqual(startDateFilter))) {
+                        return null; // 시작일 필터 불일치
+                    }
+                    return dto;
+                })
+                .filter(Objects::nonNull) // 필터링 조건에 맞지 않아 null이 된 항목 제거
+                .collect(Collectors.toList());
+
+
+        // 4. 필터링된 리스트를 Page 객체로 다시 변환하여 반환
+        return new PageImpl<>(dtoList, pageable, partyPage.getTotalElements());
+    }
 
     // 파티 정원 확인 메서드
     private void checkPartyCapacity(Party party) {


### PR DESCRIPTION
[FE 요청사항: 파티 목록 조회 API]
현재 응답값:
- id, name, leaderId, currentMembers, maxMembers, isPublic, members
추가로 필요한 값:
1. 카테고리(category) → Tag 매핑용 (study, habit, activity, care, etc)
2. 챌린지 시작일(startDate)
3. 챌린지 종료일(endDate) → 기간
4. 생성일(createDate) → 최신순 정렬 기준
5. 조회수(views) → 조회순 정렬 기준
정렬/필터 목적:
- 최신순: createDate
- 조회순: views
- 카테고리별 필터: category
- 기간/시작일 기반 필터: startDate, endDate

요청사항 완료