### PR TITLE
feat : 파티 목록 조회 api 개선

### DIFF
--- a/backend/src/main/java/com/back/domain/party/party/controller/ApiV1PartyController.java
+++ b/backend/src/main/java/com/back/domain/party/party/controller/ApiV1PartyController.java
@@ -2,7 +2,6 @@ package com.back.domain.party.party.controller;
 
 import com.back.domain.member.entity.Member;
 import com.back.domain.member.service.MemberService;
-import com.back.domain.mission.entity.Mission;
 import com.back.domain.mission.enums.MissionCategory;
 import com.back.domain.party.party.dto.*;
 import com.back.domain.party.party.entity.Party;
@@ -145,14 +144,8 @@ public class ApiV1PartyController {
     @GetMapping("/{partyId}")
     @Operation(summary = "파티 상세 조회", description = "특정 파티의 상세 정보를 조회하고 조회수를 1 증가시키는 API (미션ID 포함)")
     public ResponseEntity<ApiResponse<PartyDto>> getPartyDetails(@PathVariable Integer partyId) {
-        // 1. 파티 정보 조회 및 조회수 증가
-        Party party = partyService.getPartyDetails(partyId);
 
-        // 2. 파티에 연결된 미션 정보 조회 (Service에 추가된 헬퍼 메서드 사용)
-        Mission mission = partyService.getMissionByPartyId(partyId);
-
-        // 3. Party와 Mission 정보를 모두 DTO에 담아 반환
-        PartyDto partyDto = new PartyDto(party, mission);
+        PartyDto partyDto = partyService.getPartyDetails(partyId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/backend/src/main/java/com/back/domain/party/party/dto/PartyDto.java
+++ b/backend/src/main/java/com/back/domain/party/party/dto/PartyDto.java
@@ -29,6 +29,8 @@ public class PartyDto {
     private LocalDate endDate;
     private LocalDate createDate;
     private Integer views;
+    private String missionTitle;
+    private Boolean missionIsCompleted;
 
 
     public PartyDto(Party party, Mission mission) {
@@ -53,11 +55,24 @@ public class PartyDto {
             this.category = mission.getCategory();
             this.startDate = mission.getStartDate();
             this.endDate = mission.getEndDate();
+            this.missionTitle = mission.getTitle();
+            this.missionIsCompleted = mission.isCompleted();
+        } else {
+            this.category = null;
+            this.startDate = null;
+            this.endDate = null;
+            this.missionTitle = null;
+            this.missionIsCompleted = null;
         }
 
         this.members = party.getPartyMembers().stream()
                 .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
-                .map(partyMember -> new PartyMemberDto(partyMember.getMember()))
+                .map(partyMember -> {
+                    return new PartyMemberDto(
+                            partyMember.getMember(),
+                            null
+                    );
+                })
                 .collect(Collectors.toList());
     }
 
@@ -79,10 +94,12 @@ public class PartyDto {
         this.category = null;
         this.startDate = null;
         this.endDate = null;
+        this.missionTitle = null;
+        this.missionIsCompleted = null;
 
         this.members = party.getPartyMembers().stream()
                 .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
-                .map(partyMember -> new PartyMemberDto(partyMember.getMember()))
+                .map(partyMember -> new PartyMemberDto(partyMember.getMember(), null))
                 .collect(Collectors.toList());
     }
 

--- a/backend/src/main/java/com/back/domain/party/party/dto/PartyMemberDto.java
+++ b/backend/src/main/java/com/back/domain/party/party/dto/PartyMemberDto.java
@@ -12,6 +12,14 @@ public class PartyMemberDto {
     private Integer id;
     private String email;
     private String name;
+    private String status;
+
+    public PartyMemberDto(Member member, String missionStatus) {
+        this.id = member.getId();
+        this.email = member.getEmail();
+        this.name = member.getName();
+        this.status = missionStatus;
+    }
 
     public PartyMemberDto(Member member) {
         this.id = member.getId();

--- a/backend/src/main/java/com/back/domain/party/party/service/PartyService.java
+++ b/backend/src/main/java/com/back/domain/party/party/service/PartyService.java
@@ -4,8 +4,10 @@ import com.back.domain.member.entity.Member;
 import com.back.domain.member.repository.MemberRepository;
 import com.back.domain.mission.entity.Mission;
 import com.back.domain.mission.enums.MissionCategory;
+import com.back.domain.mission.repository.MissionCompletionLogRepository;
 import com.back.domain.mission.repository.MissionRepository;
 import com.back.domain.party.party.dto.PartyDto;
+import com.back.domain.party.party.dto.PartyMemberDto;
 import com.back.domain.party.party.dto.PartyRequestDto;
 import com.back.domain.party.party.dto.PartyUpdateRequestDto;
 import com.back.domain.party.party.entity.Party;
@@ -41,6 +43,8 @@ public class PartyService {
     private final MemberRepository memberRepository;
     private final PartyMemberRepository partyMemberRepository;
     private final MissionRepository missionRepository;
+    private final MissionCompletionLogRepository completionLogRepository;
+
 
     public Page<PartyDto> getPublicPartyList(
             Pageable pageable,
@@ -210,23 +214,44 @@ public class PartyService {
         partyRepository.delete(party);
     }
 
+    private String getMemberMissionStatus(Integer missionId, Integer memberId) {
+        boolean isCompleted = completionLogRepository.existsByMissionIdAndMemberId(missionId, memberId);
+        return isCompleted ? "COMPLETED" : "PROGRESS";
+    }
+
+    // 파티 상세 조회 (캐시 적용)
     @Cacheable(value = "partyDetails", key = "#partyId")
-    @Transactional
-    public Party getPartyDetails(Integer partyId) {
+    @Transactional(readOnly = true)
+    public PartyDto getPartyDetails(Integer partyId) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND, "파티를 찾을 수 없습니다."));
 
         party.incrementViews();
 
-        return party;
-    }
+        Mission mission = missionRepository.findByPartyId(partyId).stream().findFirst().orElse(null);
 
-    @Cacheable(value = "missionByParty", key = "#partyId")
-    @Transactional(readOnly = true)
-    public Mission getMissionByPartyId(Integer partyId) {
-        return missionRepository.findByPartyId(partyId).stream()
-                .findFirst()
-                .orElse(null);
+        // 파티원 DTO 리스트 생성 로직
+        List<PartyMemberDto> memberDtos = party.getPartyMembers().stream()
+                .filter(pm -> pm.getStatus() == PartyMemberStatus.ACCEPTED)
+                .map(partyMember -> {
+                    String memberMissionStatus = null;
+                    if (mission != null) {
+                        memberMissionStatus = getMemberMissionStatus( // 상태 계산 로직 사용
+                                mission.getId(),
+                                partyMember.getMember().getId()
+                        );
+                    }
+                    return new PartyMemberDto(
+                            partyMember.getMember(),
+                            memberMissionStatus
+                    );
+                })
+                .collect(Collectors.toList());
+
+        PartyDto dto = new PartyDto(party, mission);
+        dto.setMembers(memberDtos);
+
+        return dto;
     }
 
     @Transactional


### PR DESCRIPTION
프론트에서 요청한 

[추가 개발 요청 드립니다 ]
- 요청 배경: 프론트엔드에서 진행도/완료 등 멤버별 상태를 표시해야 하는데, 현재 파티 상세/목록 API의 members 배열에는 status(PROGRESS,COMPLETED) 정보가 포함되어 있지 않습니다.
- 현재 상황: API 응답의 members는 { id, email, name }만 내려오고 있습니다.
- 요청 사항: 파티 상세/목록 API의 members 배열에 status 필드를 추가해주실 수 있을까요? (예: { id, email, name, status })
[변경 요청 예시]
```json
"members": [
  {
    "id": 3,
    "email": "[user3@user.com](mailto:user3@user.com)",
    "name": "유저3",
    "status": "COMPLETED"
  }
]
[API 개선 요청] 파티 목록(/api/v1/parties) 응답에 missionTitle, missionIsCompleted 필드 추가 요청드립니다. :절하는_남성:
요청 배경:
프론트엔드의 진행 현황(Progress) 화면에서
 각 파티의 **미션 제목(missionTitle)**과 **진행 상태(missionIsCompleted)**를 함께 표시해야 합니다.
 현재 목록 API(GET /api/v1/parties) 응답에는 두 필드가 포함되어 있지 않아
 UI에서 제목이 비어 있거나 진행 상태를 정확히 판별할 수 없는 상황입니다.
현재 상황:
GET /api/v1/parties 응답 예시는 아래와 같습니다.
{
  "id": 5,
  "name": "영어 단어 암기",
  "leaderId": 1,
  "missionId": 5,
  "category": "LEARNING",
  "currentMembers": 4,
  "maxMembers": 12,
  "isPublic": true,
  "startDate": "2025-09-22",
  "endDate": "2025-10-22",
  "createDate": "2025-09-26",
  "views": 22
}
현재 missionTitle, missionIsCompleted 필드가 포함되어 있지 않습니다.
요청 사항:
GET /api/v1/parties 목록 응답에 아래 두 필드를 추가해주실 수 있을까요? :기도:
PARTY.MISSION_ID를 기준으로 MISSIONS 테이블을 JOIN하여
TITLE, IS_COMPLETED 컬럼 값을 함께 내려주시면 정말 감사하겠습니다.
{
  "id": 5,
  "name": "영어 단어 암기",
  "leaderId": 1,
  "missionId": 5,
  "missionTitle": "AI 추천 단어 암기 미션",   //  추가 요청 필드
  "missionIsCompleted": false,                //  추가 요청 필드
  "category": "LEARNING",
  "currentMembers": 4,
  "maxMembers": 12,
  "isPublic": true,
  "startDate": "2025-09-22",
  "endDate": "2025-10-22",
  "createDate": "2025-09-26",
  "views": 22
}

개선 완료